### PR TITLE
Fix include headers for linking

### DIFF
--- a/build/automake/Makefile.am
+++ b/build/automake/Makefile.am
@@ -42,6 +42,9 @@ pkginclude_HEADERS = \
 			../../../src/Utilities/StringTokenizer.h \
 			../../../src/Utilities/extra.h \
 			../../../src/Utilities/stat.h  \
+			../../../src/BipartiteGraphPartialColoring/BipartiteGraphPartialColoringInterface.h \
+			../../../src/BipartiteGraphPartialColoring/BipartiteGraphPartialOrdering.h \
+			../../../src/BipartiteGraphPartialColoring/BipartiteGraphPartialColoring.h \
 			../../../src/BipartiteGraphBicoloring/BipartiteGraphBicoloringInterface.h \
 			../../../src/BipartiteGraphBicoloring/BipartiteGraphVertexCover.h \
 			../../../src/BipartiteGraphBicoloring/BipartiteGraphOrdering.h \
@@ -62,9 +65,6 @@ pkginclude_HEADERS = \
 
 if ENABLE_OPENMP
 pkginclude_HEADERS += \
-			../../../src/BipartiteGraphPartialColoring/BipartiteGraphPartialColoringInterface.h \
-			../../../src/BipartiteGraphPartialColoring/BipartiteGraphPartialOrdering.h \
-			../../../src/BipartiteGraphPartialColoring/BipartiteGraphPartialColoring.h \
 			../../../src/SMPGC/SMPGC.h \
 			../../../src/SMPGC/SMPGCGraph.h \
 			../../../src/SMPGC/SMPGCOrdering.h \


### PR DESCRIPTION
The three `BipartiteGraphPartial*.h` headers are included from the main `ColPack/ColPackHeaders.h`. Without installing them, ColPack_jll cannot be used to link to, since includeing the main header file fails.